### PR TITLE
TyreCompound typo and nil values

### DIFF
--- a/Assetto Corsa/apps/lua/SimHubUDPConnector/extensions/TyreOptimalTempExtension.lua
+++ b/Assetto Corsa/apps/lua/SimHubUDPConnector/extensions/TyreOptimalTempExtension.lua
@@ -27,7 +27,7 @@ local wheelsState = carState.wheels ---@type ac.StateWheel
 local function maximumOptimalTemperature(compoundName, minTemp)
 	if (compoundName == nil) then
 		-- in replays those values are nil
-		return minTemp and (minTemp + 30) or 80
+		return nil
 	end
 	if string.find(compoundName, "Street") then
 		return minTemp + 10

--- a/Assetto Corsa/apps/lua/SimHubUDPConnector/extensions/TyreOptimalTempExtension.lua
+++ b/Assetto Corsa/apps/lua/SimHubUDPConnector/extensions/TyreOptimalTempExtension.lua
@@ -54,7 +54,7 @@ function TyreOptimalTempExtension:update(dt, customData)
 	customData.IdealPressureFront = carsUtils.getTyreConfigValue(carState.compoundIndex, true, "PRESSURE_IDEAL", 0)
 	customData.IdealPressureRear = carsUtils.getTyreConfigValue(carState.compoundIndex, false, "PRESSURE_IDEAL", 0)
 	customData.MinimumOptimalTemperature = wheelsState[0].tyreOptimumTemperature
-	customData.MaximumOptimalTemperature = maximumOptimalTemperature(customData.tyreCompound,
+	customData.MaximumOptimalTemperature = maximumOptimalTemperature(customData.TyreCompound,
 		customData.MinimumOptimalTemperature)
 	if ac.getPatchVersionCode() >= 3334 then
 		-- if (cspVersion:versionCompare("0.2.7") > -1) then


### PR DESCRIPTION
There was one other capitilisation missed from my patch - fixed in https://github.com/Dasde/SimHubUDPConnector/commit/d0bebaa0ef8fe2a46ac39e120a3f7a72f5b368f9

Is the check for compoundName is nil when you are running an AC replay?    I have never tried that, only use the simhub replay and fixed the formulas I needed once.   In any case, I would prefer that the maxoptimaltemp is set to nil if the compoundName is nil as this will match all the other invalid data.   See https://github.com/Dasde/SimHubUDPConnector/commit/83eb322c6c17320e1a8e84ee79b65a94d8986d0d