### PR TITLE
Change getTyresLongName to getTyresName

### DIFF
--- a/Assetto Corsa/apps/lua/SimHubUDPConnector/extensions/TyreExtension.lua
+++ b/Assetto Corsa/apps/lua/SimHubUDPConnector/extensions/TyreExtension.lua
@@ -103,7 +103,7 @@ end
 local timeSinceLastUpdate = 0
 
 function TyreExtension:update(dt, customData)
-	customData.TyreCompound = ac.getTyresLongName(0, carState.compoundIndex)
+	customData.TyreCompound = ac.getTyresName(0, carState.compoundIndex)
 	customData.IdealPressureFront = carsUtils.getTyreConfigValue(carState.compoundIndex, true, "PRESSURE_IDEAL", 0)
 	customData.IdealPressureRear = carsUtils.getTyreConfigValue(carState.compoundIndex, false, "PRESSURE_IDEAL", 0)
 	customData.MinimumOptimalTemperature = wheelsState[0].tyreOptimumTemperature


### PR DESCRIPTION
getTyresLongName does not return the correct tyre compound when the AC server has a restricted set of tyres available compared to the full set for the car.   The short version is accurate.